### PR TITLE
Stop trying to build after install

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "lint": "npm run lint:eslint && npm run lint:prettier",
     "lint:eslint": "eslint *.ts --ignore-path .gitignore",
     "lint:prettier": "prettier --check *.ts --ignore-path .gitignore",
-    "postinstall": "npm run build",
     "prepublishOnly": "npm run build"
   },
   "license": "MIT",


### PR DESCRIPTION
This causes errors when you try to install in a production like environment that doesn't have TypeScript installed.