### PR TITLE
Add HTMLElementTagNameMap interface

### DIFF
--- a/lite-youtube.ts
+++ b/lite-youtube.ts
@@ -360,3 +360,9 @@ export class LiteYTEmbed extends HTMLElement {
 }
 // Register custom element
 customElements.define('lite-youtube', LiteYTEmbed);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lite-youtube': LiteYTEmbed;
+  }
+}


### PR DESCRIPTION
To fix this kind of linter warnings:

<img width="325" alt="Screenshot 2020-04-18 at 22 42 53" src="https://user-images.githubusercontent.com/1007051/79670812-fd834380-81c5-11ea-9913-50a39501ee5b.png">

Docs: https://github.com/runem/lit-analyzer/tree/master/packages/lit-analyzer#-no-unknown-tag-name