### PR TITLE
Fix videoStartAt property

### DIFF
--- a/lite-youtube.ts
+++ b/lite-youtube.ts
@@ -67,11 +67,11 @@ export class LiteYTEmbed extends HTMLElement {
   }
 
   get videoStartAt(): number {
-    return Number(this.getAttribute('videoPlay') || '0');
+    return Number(this.getAttribute('videoStartAt') || '0');
   }
 
   set videoStartAt(time: number) {
-    this.setAttribute('videoPlay', String(time));
+    this.setAttribute('videoStartAt', String(time));
   }
 
   get autoLoad(): boolean {


### PR DESCRIPTION
Probably a wrong copy/paste?

I'm not sure about the camelcase. Because there are: `videoid`, `videotitle`, `videoPlay`, `autoload`, etc.