### PR TITLE
fix(css): placeholder position with different text-align

### DIFF
--- a/lite-youtube.ts
+++ b/lite-youtube.ts
@@ -122,6 +122,7 @@ export class LiteYTEmbed extends HTMLElement {
           position: absolute;
           width: 100%;
           height: 100%;
+          left: 0;
         }
 
         #frame {


### PR DESCRIPTION
Fixes issue where `#fallbackPlaceholder` becomes misaligned if parent has `text-align` not set to `left`.

This is the current demo page with
```css
body {
    text-align: center;
}
```
<img width="1080" alt="Screen Shot 2021-11-26 at 00 36 30" src="https://user-images.githubusercontent.com/33553182/143501849-3b902230-222a-49c2-a707-36d73f42d58b.png">