### PR TITLE
HTMLMediaElement events

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,23 +119,56 @@ Use any [YouTube Embedded Players and Player Parameters](https://developers.goog
 The web component allows certain attributes to be give a little additional
 flexibility.
 
-| Name           | Description                                                      | Default |
-| -------------- | ---------------------------------------------------------------- | ------- |
-| `videoid`      | The YouTube videoid                                              | ``      |
-| `playlistid`   | The YouTube playlistid; requires a videoid for thumbnail         | ``      |
-| `videotitle`   | The title of the video                                           | `Video` |
-| `videoplay`    | The title of the play button (for translation)                   | `Play`  |
-| `videoStartAt` | Set the point at which the video should start, in seconds        | `0`     |
-| `posterquality`| Set thumbnail poster quality (maxresdefault, sddefault, mqdefault, hqdefault) | `hqdefault`  |
-| `posterloading`| Set img lazy load attr `loading` for poster image | `lazy`  |
-| `nocookie`     | Use youtube-nocookie.com as iframe embed uri | `false` |
-| `autoload`     | Use Intersection Observer to load iframe when scrolled into view | `false` |
-| `params`       | Set YouTube query parameters                                     | ``      |
+| Name            | Description                                                                  | Default       |
+|-----------------|------------------------------------------------------------------------------|---------------|
+| `videoid`       | The YouTube videoid                                                          | ``            |
+| `playlistid`    | The YouTube playlistid; requires a videoid for thumbnail                     | ``            |
+| `videotitle`    | The title of the video                                                       | `Video`       |
+| `videoplay`     | The title of the play button (for translation)                               | `Play`        |
+| `videoStartAt`  | Set the point at which the video should start, in seconds                    | `0`           |
+| `posterquality` | Set thumbnail poster quality (maxresdefault, sddefault, mqdefault, hqdefault) | `hqdefault`  |
+| `posterloading` | Set img lazy load attr `loading` for poster image                            | `lazy`        |
+| `nocookie`      | Use youtube-nocookie.com as iframe embed uri                                 | `false`       |
+| `autoload`      | Use Intersection Observer to load iframe when scrolled into view             | `false`       |
+| `params`        | Set YouTube query parameters                                                 | ``            |
+| `events`        | Emit events (similar to `<video>` events) using Youtube Iframe api           | ``            |
+
 
 ## Events
 
 The web component fires events to give the ability understand important lifecycle.
 
-| Event Name     | Description                                                      | Returns |
-| -------------- | ---------------------------------------------------------------- | ------- |
-| `liteYoutubeIframeLoaded` | When the iframe is loaded, allowing us of JS API  | `detail: { videoId: this.videoId }` |
+| Event Name                | Description                                                     | Returns                             |
+|---------------------------|-----------------------------------------------------------------|-------------------------------------|
+| `liteYoutubeIframeLoaded` | When the iframe is loaded, allowing us of JS API                | `detail: { videoId: this.videoId }` |
+| `ratechange`              | The playback rate has changed.                                  | {}                                  |
+| `loadedmetadata`          | The metadata has been loaded.                                   | {}                                  |
+| `play`                    | Playback has begun.                                             | {}                                  |
+| `pause`                   | Playback has been paused.                                       | {}                                  |
+| `ended`                   | Playback has stopped because the end of the media was reached.  | {}                                  |
+
+## Properties
+
+If `events` attribute is set, then the element will act as an HTMLMediaElement element and will give you access to specific
+properties
+
+| Property Name  | Description                                                                                 | Writable |
+|----------------|---------------------------------------------------------------------------------------------|----------|
+| `currentTime`  | A double-precision floating-point value indicating the current playback time in seconds.    | Y        |
+| `duration`     | A double-precision floating-point value indicating the duration of the media in seconds.    | N        |
+| `ended`        | A boolean value which is `true` if the media contained in the element has finished playing. | N        |
+| `muted`        | A boolean value. `true` means muted and `false` means not muted.                            | Y        |
+| `paused`       | A boolean value. `true` is paused and `false` is not paused.                                | N        |
+| `playbackRate` | The rate at which the media is being played back                                            | Y        |
+| `volume`       | The volume at which the media will be played.                                               | Y        |
+
+## Methods
+
+If `events` attribute is set, then the element will act as an HTMLMediaElement element and will give you access to specific
+methods
+
+| Method Name | Description                              |
+|-------------|------------------------------------------|
+| `play`      | Attempts to begin playback of the media. |
+| `pause`     | Attempts to pause playback of the media. |
+| `load`      | Loads the player                         |

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ flexibility.
 | `videotitle`    | The title of the video                                                         | `Video`       |
 | `videoplay`     | The title of the play button (for translation)                                 | `Play`        |
 | `videoStartAt`  | Set the point at which the video should start, in seconds                      | `0`           |
-| `posterquality` | Set thumbnail poster quality (maxresdefault, sddefault, mqdefault, hqdefault)  | `hqdefault`  |
+| `posterquality` | Set thumbnail poster quality (maxresdefault, sddefault, mqdefault, hqdefault)  | `hqdefault`   |
 | `posterloading` | Set img lazy load attr `loading` for poster image                              | `lazy`        |
 | `nocookie`      | Use youtube-nocookie.com as iframe embed uri                                   | `false`       |
 | `autoload`      | Use Intersection Observer to load iframe when scrolled into view               | `false`       |

--- a/README.md
+++ b/README.md
@@ -119,19 +119,19 @@ Use any [YouTube Embedded Players and Player Parameters](https://developers.goog
 The web component allows certain attributes to be give a little additional
 flexibility.
 
-| Name            | Description                                                                  | Default       |
-|-----------------|------------------------------------------------------------------------------|---------------|
-| `videoid`       | The YouTube videoid                                                          | ``            |
-| `playlistid`    | The YouTube playlistid; requires a videoid for thumbnail                     | ``            |
-| `videotitle`    | The title of the video                                                       | `Video`       |
-| `videoplay`     | The title of the play button (for translation)                               | `Play`        |
-| `videoStartAt`  | Set the point at which the video should start, in seconds                    | `0`           |
-| `posterquality` | Set thumbnail poster quality (maxresdefault, sddefault, mqdefault, hqdefault) | `hqdefault`  |
-| `posterloading` | Set img lazy load attr `loading` for poster image                            | `lazy`        |
-| `nocookie`      | Use youtube-nocookie.com as iframe embed uri                                 | `false`       |
-| `autoload`      | Use Intersection Observer to load iframe when scrolled into view             | `false`       |
-| `params`        | Set YouTube query parameters                                                 | ``            |
-| `events`        | Emit events (similar to `<video>` events) using Youtube Iframe api           | ``            |
+| Name            | Description                                                                    | Default       |
+|-----------------|--------------------------------------------------------------------------------|---------------|
+| `videoid`       | The YouTube videoid                                                            | ``            |
+| `playlistid`    | The YouTube playlistid; requires a videoid for thumbnail                       | ``            |
+| `videotitle`    | The title of the video                                                         | `Video`       |
+| `videoplay`     | The title of the play button (for translation)                                 | `Play`        |
+| `videoStartAt`  | Set the point at which the video should start, in seconds                      | `0`           |
+| `posterquality` | Set thumbnail poster quality (maxresdefault, sddefault, mqdefault, hqdefault)  | `hqdefault`  |
+| `posterloading` | Set img lazy load attr `loading` for poster image                              | `lazy`        |
+| `nocookie`      | Use youtube-nocookie.com as iframe embed uri                                   | `false`       |
+| `autoload`      | Use Intersection Observer to load iframe when scrolled into view               | `false`       |
+| `params`        | Set YouTube query parameters                                                   | ``            |
+| `events`        | Emit events (similar to `<video>` events) using Youtube Iframe api             | ``            |
 
 
 ## Events

--- a/demo/index.html
+++ b/demo/index.html
@@ -136,7 +136,6 @@
       playlistid="PL-G5r6j4GptH5JTveoLTVqpp7w2oc27Q9"
     ></lite-youtube>
 
-
     <h3>YouTube Events</h3>
     <pre>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -135,5 +135,18 @@
       videoid="VLrYOji75Vc"
       playlistid="PL-G5r6j4GptH5JTveoLTVqpp7w2oc27Q9"
     ></lite-youtube>
+
+
+    <h3>YouTube Events</h3>
+    <pre>
+
+&lt;lite-youtube videoid=&quot;guJLfqTFfIw&quot; events&gt;&lt;/lite-youtube&gt;
+    </pre>
+    <lite-youtube videoid="guJLfqTFfIw" events
+                  onplay="console.log('play')"
+                  onpause="console.log('pause')"
+                  onended="console.log('ended')"
+                  onratechange="console.log('playback rate :', this.playbackRate)"
+    ></lite-youtube>
   </body>
 </html>

--- a/lite-youtube.ts
+++ b/lite-youtube.ts
@@ -14,6 +14,7 @@ async function loadYoutubeAPI(): Promise<typeof window.YT> {
     }
     const tag = document.createElement('script');
     tag.src = 'https://www.youtube.com/iframe_api';
+    tag.type = 'text/javascript';
     const firstScriptTag = document.getElementsByTagName('script')[0];
     firstScriptTag.parentNode!.insertBefore(tag, firstScriptTag);
     window.onYouTubeIframeAPIReady = function () {

--- a/lite-youtube.ts
+++ b/lite-youtube.ts
@@ -1,8 +1,5 @@
 declare global {
   interface Window {
-    YT?: {
-      Player: YT.Player;
-    };
     onYouTubeIframeAPIReady?: () => void;
   }
 }
@@ -46,15 +43,12 @@ export class LiteYTEmbed extends HTMLElement {
   shadowRoot!: ShadowRoot;
 
   private player?: YT.Player;
-
   private domRefFrame!: HTMLDivElement;
-
   private domRefImg!: {
     fallback: HTMLImageElement;
     webp: HTMLSourceElement;
     jpeg: HTMLSourceElement;
   };
-
   private domRefPlayButton!: HTMLButtonElement;
 
   private static isPreconnected = false;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@esm-bundle/chai": "^4.3.4-fix.0",
     "@open-wc/eslint-config": "^4.3.0",
     "@open-wc/testing": "^2.5.33",
+    "@types/youtube": "^0.0.46",
     "@typescript-eslint/eslint-plugin": "^2.29.0",
     "@typescript-eslint/parser": "^2.29.0",
     "@web/dev-server": "^0.1.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,6 +469,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/youtube@^0.0.46":
+  version "0.0.46"
+  resolved "https://registry.yarnpkg.com/@types/youtube/-/youtube-0.0.46.tgz#925afdf741f35279114da7c58c98013868a949f5"
+  integrity sha512-Yf1Y4bDj/QIn8v+zdy0l7+OW6s1uoUvzVn5cGqPNCsL4iUW4gYUlIdQIRtH9NOHVgwZNLbVeeRDEn6N4RMq6Nw==
+
 "@typescript-eslint/eslint-plugin@^2.29.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"


### PR DESCRIPTION
The goal of this PR is to make this element act a bit like a [HTMLMediaElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement) adding some methods, events and properties (this element will act a bit like a `<video>` element). An attribute must be set to add this feature since I don't want to introduce perf loss when events are not necessary (there is no use in loading the API for nothing).

I understand this feature add a bit of bloat so I submit it before adding the test (to avoid working on it further if you think it's not an interesting feature for the common use case).

## ESlint & Test config 

I tried using eslint with `yarn run lint` but I got errors about missing plugins. I don't want to add additional packages so I don't know if I'm missing something

```
The plugin "eslint-plugin-wc" was referenced from the config file in "package.json...
```

Another problem appears when I try to run test (dunno if it's my env or something I should set up before runing `yarn run test`)

```
The CHROME_PATH environment variable must be set to a Chrome/Chromium executable no older than Chrome stable
```

