### PR TITLE
feat(csp): add support for csp style nonce

### DIFF
--- a/lite-youtube.ts
+++ b/lite-youtube.ts
@@ -111,8 +111,12 @@ export class LiteYTEmbed extends HTMLElement {
    */
   private setupDom(): void {
     const shadowDom = this.attachShadow({ mode: 'open' });
+    let nonce = '';
+    if (window.liteYouTubeNonce) {
+      nonce = `nonce="${window.liteYouTubeNonce}"`;
+    }
     shadowDom.innerHTML = `
-      <style>
+      <style ${nonce}>
         :host {
           contain: content;
           display: block;
@@ -445,5 +449,8 @@ customElements.define('lite-youtube', LiteYTEmbed);
 declare global {
   interface HTMLElementTagNameMap {
     'lite-youtube': LiteYTEmbed;
+  }
+  interface Window {
+    liteYouTubeNonce: string;
   }
 }

--- a/test/lite-youtube.test.ts
+++ b/test/lite-youtube.test.ts
@@ -166,6 +166,16 @@ describe('<lite-youtube>', () => {
     expect(el['isYouTubeShort']()).to.be.equal(true);
   });
 
+  it('check for nonce injector', async () => {
+    window.liteYouTubeNonce = 'test-abcd1234';
+    const el = await fixture<LiteYTEmbed>(
+      html`<lite-youtube videoid="guJLfqTFfIw"></lite-youtube>`
+    );
+    expect(
+      el.shadowRoot.querySelector('style')?.getAttribute('nonce')
+    ).to.equal(window.liteYouTubeNonce);
+  });
+
   it('is valid A11y via aXe', async () => {
     const el = await fixture<LiteYTEmbed>(baseTemplate);
     await expect(el).shadowDom.to.be.accessible();


### PR DESCRIPTION
This allows setting the global `window.liteYouTubeNonce` to a nonce to allows support in environments where the CSP disallows use of `unsafe-inline`. 