### PR TITLE
Add shadow DOM ::part support

### DIFF
--- a/lite-youtube.ts
+++ b/lite-youtube.ts
@@ -193,13 +193,13 @@ export class LiteYTEmbed extends HTMLElement {
           display: none;
         }
       </style>
-      <div id="frame">
-        <picture>
+      <div id="frame" part="frame">
+        <picture part="picture-frame">
           <source id="webpPlaceholder" type="image/webp">
           <source id="jpegPlaceholder" type="image/jpeg">
-          <img id="fallbackPlaceholder" referrerpolicy="origin" loading="lazy">
+          <img id="fallbackPlaceholder" referrerpolicy="origin" loading="lazy" part="picture">
         </picture>
-        <button id="playButton"></button>
+        <button id="playButton" part="play-button"></button>
       </div>
     `;
     this.domRefFrame = shadowDom.querySelector<HTMLDivElement>('#frame')!;


### PR DESCRIPTION
By default, there is no way to customise elements within a shadow DOM since they fall into their own context. The `::part` pseudo-element allows external CSS to access to the shadow tree and add such customisations without the need to use JavaScript.

See the following link for further details.
https://developer.mozilla.org/en-US/docs/Web/CSS/::part