### PR TITLE
fix(firefox): position absolute with slot does not assume 0

### DIFF
--- a/demo/slot.html
+++ b/demo/slot.html
@@ -32,12 +32,15 @@
     </style>
   </head>
   <body>
-
-
-&lt;lite-youtube videoid=&quot;guJLfqTFfIw&quot; nocookie&lt;/lite-youtube&gt;
+    <pre>
+      <lite-youtube
+        videoid="guJLfqTFfIw" posterquality="maxresdefault"  disablenoscript
+      >
+        <img slot="image" src="https://storage.googleapis.com/jdr-public-imgs/pages/page-4-test.jpg">
+      </lite-youtube>
     </pre>
     <lite-youtube
-      videoid="guJLfqTFfIw"
+      videoid="guJLfqTFfIw" posterquality="maxresdefault"  disablenoscript
     >
       <img slot="image" src="https://storage.googleapis.com/jdr-public-imgs/pages/page-4-test.jpg">
     </lite-youtube>

--- a/lite-youtube.ts
+++ b/lite-youtube.ts
@@ -155,6 +155,7 @@ export class LiteYTEmbed extends HTMLElement {
           width: 100%;
           height: 100%;
           left: 0;
+          top: 0;
         }
 
         #frame {


### PR DESCRIPTION
Resolve #132 

Odd; Firefox, only with the outside slot defined, mis-positions the iframe when loaded (assumes position:absolute !== top:0).