### PR TITLE
Adding support for standard <video> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - _new in v1.6_: Adds `autoPause` for pausing videos scrolled off screen; adds `--lite-youtube-aspect-ratio` CSS custom property create custom aspect ratio videos; adds `--lite-youtube-frame-shadow-visible` CSS custom property to disable frame shadow (flat look); adds a named slot `image` that allows for setting custom poster image; adds `credentialless` for COEP
 - _new in v1.7_: Adds support for 404 fallback posters; add noscript injector to lightdom for search indexing (disable via `disablenoscript` attribute in v1.7.1).
 - _new in v1.8_: Adds support for styling the play button via `::part` (thank you [@Lukinoh](https://github.com/Lukinoh)!).
+- Adds support for standard `<video>` tag with `lite-youtube` attribute for compatibility with platforms that filter custom HTML tags (like Shopify).
 
 ## Install via package manager
 
@@ -55,9 +56,21 @@ If you want the paste-and-go version, you can simply load it via CDN:
 
 ## Basic Usage
 
+### Using Custom Element (Traditional)
+
 ```html
 <lite-youtube videoid="guJLfqTFfIw"></lite-youtube>
 ```
+
+### Using Standard Video Tag (New in v2.0)
+
+For compatibility with platforms that filter custom HTML tags (like Shopify), you can now use the standard `<video>` tag with a `lite-youtube` attribute:
+
+```html
+<video lite-youtube videoid="guJLfqTFfIw"></video>
+```
+
+Both methods support all the same attributes and functionality. The `<video lite-youtube>` syntax will automatically be converted to a `<lite-youtube>` element when the script loads.
 
 ## Basic Usage with Fallback Link
 
@@ -68,10 +81,20 @@ A fallback appears in any of the following circumstances:
 1. When JS fails or the lite-youtube script is not loaded/executed
 1. When the browser doesn't support web components
 
+### With Custom Element
+
 ```html
 <lite-youtube videoid="guJLfqTFfIw">
   <a class="lite-youtube-fallback" href="https://www.youtube.com/watch?v=guJLfqTFfIw">Watch on YouTube: "Sample output of devtools-to-video cli tool"</a>
 </lite-youtube>
+```
+
+### With Video Tag
+
+```html
+<video lite-youtube videoid="guJLfqTFfIw">
+  <a class="lite-youtube-fallback" href="https://www.youtube.com/watch?v=guJLfqTFfIw">Watch on YouTube: "Sample output of devtools-to-video cli tool"</a>
+</video>
 ```
 
 Example CSS:
@@ -112,6 +135,8 @@ Example CSS:
 
 Setting the YouTube playlistid allows the playlist interface to load on interaction. Note, this still requires a videoid for to load a placeholder thumbnail as YouTube does not return a thumbnail for playlists in the API.
 
+### Custom Element
+
 ```html
 <lite-youtube
   videoid="VLrYOji75Vc"
@@ -119,7 +144,19 @@ Setting the YouTube playlistid allows the playlist interface to load on interact
 ></lite-youtube>
 ```
 
+### Video Tag
+
+```html
+<video
+  lite-youtube
+  videoid="VLrYOji75Vc"
+  playlistid="PL-G5r6j4GptH5JTveoLTVqpp7w2oc27Q9"
+></video>
+```
+
 ## Add Video Title
+
+### Custom Element
 
 ```html
 <lite-youtube
@@ -128,7 +165,19 @@ Setting the YouTube playlistid allows the playlist interface to load on interact
 ></lite-youtube>
 ```
 
-## Update interface for Locale</h3>
+### Video Tag
+
+```html
+<video
+  lite-youtube
+  videotitle="This is a video title"
+  videoid="guJLfqTFfIw"
+></video>
+```
+
+## Update interface for Locale
+
+### Custom Element
 
 ```html
 <lite-youtube
@@ -137,6 +186,18 @@ Setting the YouTube playlistid allows the playlist interface to load on interact
   videoid="guJLfqTFfIw"
 >
 </lite-youtube>
+```
+
+### Video Tag
+
+```html
+<video
+  lite-youtube
+  videoplay="Mirar"
+  videotitle="Mis hijos se burlan de mi español"
+  videoid="guJLfqTFfIw"
+>
+</video>
 ```
 
 ## Style It
@@ -152,6 +213,8 @@ Height and Width are responsive in the component.
 </style>
 <div class="styleIt">
   <lite-youtube videoid="guJLfqTFfIw"></lite-youtube>
+  <!-- OR -->
+  <video lite-youtube videoid="guJLfqTFfIw"></video>
 </div>
 ```
 
@@ -161,6 +224,8 @@ See [the example video](https://www.youtube.com/watch?v=aw7CRQTuRfo) of how this
 
 ```html
 <lite-youtube videoid="vMImN9gghao" short></lite-youtube>
+<!-- OR -->
+<video lite-youtube videoid="vMImN9gghao" short></video>
 ```
 
 ## AutoLoad with IntersectionObserver
@@ -169,6 +234,8 @@ Uses Intersection Observer if available to automatically load the YouTube iframe
 
 ```html
 <lite-youtube videoid="guJLfqTFfIw" autoload> </lite-youtube>
+<!-- OR -->
+<video lite-youtube videoid="guJLfqTFfIw" autoload></video>
 ```
 
 ## Set a video start time
@@ -176,6 +243,8 @@ Uses Intersection Observer if available to automatically load the YouTube iframe
 ```html
 <!-- Start at 5 seconds -->
 <lite-youtube videoid="guJLfqTFfIw" videoStartAt="5"></lite-youtube>
+<!-- OR -->
+<video lite-youtube videoid="guJLfqTFfIw" videoStartAt="5"></video>
 ```
 
 ## Fine tune the poster quality for a video
@@ -185,6 +254,12 @@ Uses Intersection Observer if available to automatically load the YouTube iframe
   videoid="guJLfqTFfIw"
   posterquality="maxresdefault"
 ></lite-youtube>
+<!-- OR -->
+<video
+  lite-youtube
+  videoid="guJLfqTFfIw"
+  posterquality="maxresdefault"
+></video>
 ```
 
 ## Use the named slot to set a custom poster image
@@ -192,6 +267,10 @@ Uses Intersection Observer if available to automatically load the YouTube iframe
 <lite-youtube videoid="guJLfqTFfIw">
   <img slot="image" src="my-poster-override.jpg">
 </lite-youtube>
+<!-- OR -->
+<video lite-youtube videoid="guJLfqTFfIw">
+  <img slot="image" src="my-poster-override.jpg">
+</video>
 ```
 
 ## Set custom aspect ratio
@@ -202,6 +281,8 @@ Uses Intersection Observer if available to automatically load the YouTube iframe
   }
 </style>
 <lite-youtube videoid="guJLfqTFfIw"></lite-youtube>
+<!-- OR -->
+<video lite-youtube videoid="guJLfqTFfIw"></video>
 ```
 
 ## Disable the frame shadow (flat look)
@@ -213,6 +294,8 @@ Uses Intersection Observer if available to automatically load the YouTube iframe
   }
 </style>
 <lite-youtube videoid="guJLfqTFfIw"></lite-youtube>
+<!-- OR -->
+<video lite-youtube videoid="guJLfqTFfIw"></video>
 ```
 
 ## Customize the play button
@@ -223,18 +306,24 @@ Uses Intersection Observer if available to automatically load the YouTube iframe
   }
 </style>
 <lite-youtube videoid="guJLfqTFfIw"></lite-youtube>
+<!-- OR -->
+<video lite-youtube videoid="guJLfqTFfIw"></video>
 ```
 
 ## Auto-Pause video when scrolled out of view
 Note: the custom poster image will load with this set, but will then disappear without any user interaction because of the intersection observer starting.
 ```html
  <lite-youtube videoid="VLrYOji75Vc" autopause></lite-youtube>
+ <!-- OR -->
+ <video lite-youtube videoid="VLrYOji75Vc" autopause></video>
 ```
 
 ## NoScript disable
 As of v1.7.0, we inject into the lightdom a noscript for SEO help. This can conflict with server side rendered noscript injects. To disable, simply pass `disablenoscript` to the component:
 ```html
  <lite-youtube videoid="VLrYOji75Vc" disablenoscript></lite-youtube>
+ <!-- OR -->
+ <video lite-youtube videoid="VLrYOji75Vc" disablenoscript></video>
 ```
 
 ## YouTube QueryParams
@@ -246,6 +335,9 @@ Use any [YouTube Embedded Players and Player Parameters](https://developers.goog
 ```html
 <lite-youtube videoid="guJLfqTFfIw" params="controls=0&enablejsapi=1">
 </lite-youtube>
+<!-- OR -->
+<video lite-youtube videoid="guJLfqTFfIw" params="controls=0&enablejsapi=1">
+</video>
 ```
 
 
@@ -277,3 +369,19 @@ The web component fires events to give the ability understand important lifecycl
 | Event Name                | Description                                      | Returns                             |
 |---------------------------|--------------------------------------------------|-------------------------------------|
 | `liteYoutubeIframeLoaded` | When the iframe is loaded, allowing us of JS API | `detail: { videoId: this.videoId }` |
+
+## Platform Compatibility
+
+### Shopify and Other Restrictive Platforms
+
+Many e-commerce and content management platforms filter out custom HTML tags for security reasons. If you're using lite-youtube on such platforms, use the `<video lite-youtube>` syntax instead:
+
+```html
+<!-- This works on Shopify and similar platforms -->
+<video lite-youtube videoid="guJLfqTFfIw"></video>
+
+<!-- This may be filtered out -->
+<lite-youtube videoid="guJLfqTFfIw"></lite-youtube>
+```
+
+The `<video lite-youtube>` tag will be automatically converted to a `<lite-youtube>` element when the script loads, providing full functionality while passing through platform filters.

--- a/demo/index.html
+++ b/demo/index.html
@@ -39,6 +39,13 @@
     </pre>
     <lite-youtube videoid="guJLfqTFfIw"></lite-youtube>
 
+    <h3>Basic Usage with Video Tag</h3>
+    <pre>
+
+&lt;video lite-youtube videoid=&quot;guJLfqTFfIw&quot;&gt;&lt;/video&gt;
+    </pre>
+    <video lite-youtube videoid="guJLfqTFfIw"></video>
+
     <h3>Add Video Title</h3>
     <pre>
 
@@ -48,6 +55,17 @@
       videoid="guJLfqTFfIw"
       videotitle="This is a video title"
     ></lite-youtube>
+
+    <h3>Add Video Title (Video Tag)</h3>
+    <pre>
+
+&lt;video lite-youtube videoid=&quot;guJLfqTFfIw&quot; videotitle=&quot;This is a video title&quot;&gt;&lt;/video&gt;
+    </pre>
+    <video
+      lite-youtube
+      videoid="guJLfqTFfIw"
+      videotitle="This is a video title"
+    ></video>
 
     <h3>Change "Play" for Locale</h3>
     <pre>

--- a/lite-youtube.ts
+++ b/lite-youtube.ts
@@ -548,12 +548,93 @@ export class LiteYTEmbed extends HTMLElement {
     window.liteYouTubeIsPreconnected = true;
   }
 }
-// Register custom element
+
+// Register custom element for lite-youtube tag
 customElements.define('lite-youtube', LiteYTEmbed);
+
+// Also register for video[lite-youtube] elements
+class LiteYTVideo extends LiteYTEmbed {
+  constructor() {
+    super();
+  }
+}
+
+// Use customElements.define with 'is' option to extend built-in video element
+// Note: This approach creates a custom element that extends HTMLVideoElement
+try {
+  customElements.define('lite-yt-video', LiteYTVideo, { extends: 'video' });
+} catch (e) {
+  // Fallback for browsers that don't support extending built-in elements
+  console.warn('lite-youtube: Browser does not support extending built-in elements');
+}
+
+// Initialize video[lite-youtube] elements on page load
+if (typeof document !== 'undefined') {
+  const initLiteYouTubeVideos = () => {
+    const videos = document.querySelectorAll('video[lite-youtube]');
+    videos.forEach((video) => {
+      // Skip if already initialized
+      if (video.hasAttribute('data-lite-youtube-initialized')) {
+        return;
+      }
+
+      // Create a lite-youtube element
+      const liteYT = document.createElement('lite-youtube') as LiteYTEmbed;
+      
+      // Copy all attributes from video to lite-youtube
+      Array.from(video.attributes).forEach((attr) => {
+        if (attr.name !== 'lite-youtube' && attr.name !== 'is') {
+          liteYT.setAttribute(attr.name, attr.value);
+        }
+      });
+
+      // Copy any child elements (like img slot)
+      while (video.firstChild) {
+        liteYT.appendChild(video.firstChild);
+      }
+
+      // Replace video with lite-youtube
+      video.parentNode?.replaceChild(liteYT, video);
+    });
+  };
+
+  // Run on DOMContentLoaded
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initLiteYouTubeVideos);
+  } else {
+    initLiteYouTubeVideos();
+  }
+
+  // Also observe for dynamically added video[lite-youtube] elements
+  if (typeof MutationObserver !== 'undefined') {
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((node) => {
+          if (node instanceof HTMLElement) {
+            if (node.tagName === 'VIDEO' && node.hasAttribute('lite-youtube')) {
+              initLiteYouTubeVideos();
+            }
+            // Check descendants
+            const videos = node.querySelectorAll?.('video[lite-youtube]');
+            if (videos && videos.length > 0) {
+              initLiteYouTubeVideos();
+            }
+          }
+        });
+      });
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+}
 
 declare global {
   interface HTMLElementTagNameMap {
     'lite-youtube': LiteYTEmbed;
+    'lite-yt-video': LiteYTVideo;
   }
   interface Window {
     liteYouTubeNonce: string;

--- a/test/lite-youtube.test.ts
+++ b/test/lite-youtube.test.ts
@@ -11,6 +11,12 @@ const baseTemplate = html`<lite-youtube
   videoid="guJLfqTFfIw"
 ></lite-youtube>`;
 
+const videoTemplate = html`<video
+  lite-youtube
+  videotitle="Test Me"
+  videoid="guJLfqTFfIw"
+></video>`;
+
 const aspectRatioTemplate = html`<lite-youtube
   style="--lite-youtube-aspect-ratio: 2 / 3;"
   videoTitle="Test Me"
@@ -296,5 +302,92 @@ describe('<lite-youtube>', () => {
   it('is valid A11y via aXe', async () => {
     const el = await fixture<LiteYTEmbed>(baseTemplate);
     await expect(el).shadowDom.to.be.accessible();
+  });
+});
+
+describe('<video lite-youtube>', () => {
+  afterEach(() => {
+    fixtureCleanup();
+  });
+
+  it('video[lite-youtube] gets converted to lite-youtube element', async () => {
+    const container = await fixture<HTMLDivElement>(
+      html`<div>${videoTemplate}</div>`,
+    );
+    
+    // Wait for the conversion to happen
+    await aTimeout(100);
+    
+    const liteYT = container.querySelector('lite-youtube');
+    expect(liteYT).to.exist;
+    expect(liteYT?.getAttribute('videoid')).to.equal('guJLfqTFfIw');
+    expect(liteYT?.getAttribute('videotitle')).to.equal('Test Me');
+  });
+
+  it('video[lite-youtube] attr sets the videoid', async () => {
+    const container = await fixture<HTMLDivElement>(
+      html`<div>${videoTemplate}</div>`,
+    );
+    
+    await aTimeout(100);
+    
+    const el = container.querySelector('lite-youtube') as LiteYTEmbed;
+    expect(el.videoId).to.equal('guJLfqTFfIw');
+  });
+
+  it('video[lite-youtube] clicking button should load iframe', async () => {
+    const container = await fixture<HTMLDivElement>(
+      html`<div>${videoTemplate}</div>`,
+    );
+    
+    await aTimeout(100);
+    
+    const el = container.querySelector('lite-youtube') as LiteYTEmbed;
+    expect(el.shadowRoot.querySelector('iframe')).to.be.null;
+    el.click();
+    expect(el.shadowRoot.querySelector('iframe')).dom.to.equal(
+      '<iframe credentialless frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="" src="https://www.youtube.com/embed/guJLfqTFfIw?autoplay=1&amp;start=0&amp;null" title="Test Me"></iframe>',
+    );
+  });
+
+  it('video[lite-youtube] with all attributes works correctly', async () => {
+    const container = await fixture<HTMLDivElement>(
+      html`<div>
+        <video
+          lite-youtube
+          videoid="guJLfqTFfIw"
+          videotitle="Full Test"
+          videoplay="Watch"
+          posterquality="maxresdefault"
+          nocookie
+        ></video>
+      </div>`,
+    );
+    
+    await aTimeout(100);
+    
+    const el = container.querySelector('lite-youtube') as LiteYTEmbed;
+    expect(el.videoId).to.equal('guJLfqTFfIw');
+    expect(el.videoTitle).to.equal('Full Test');
+    expect(el.videoPlay).to.equal('Watch');
+    expect(el.posterQuality).to.equal('maxresdefault');
+    expect(el.noCookie).to.be.true;
+  });
+
+  it('video[lite-youtube] with child elements preserves them', async () => {
+    const container = await fixture<HTMLDivElement>(
+      html`<div>
+        <video lite-youtube videoid="guJLfqTFfIw">
+          <img slot="image" src="test.jpg" />
+        </video>
+      </div>`,
+    );
+    
+    await aTimeout(100);
+    
+    const el = container.querySelector('lite-youtube') as LiteYTEmbed;
+    const slottedImg = el.querySelector('img[slot="image"]');
+    expect(slottedImg).to.exist;
+    expect(slottedImg?.getAttribute('src')).to.equal('test.jpg');
   });
 });


### PR DESCRIPTION
Hi Justin
Incredible tool - thank you very much.

We use lite-youtube embedded in our product pages on [Shopify](https://www.shopify.com). It's much faster, lighter and configurable than the standard YT embed.

Shopify implements guard-rails / lints raw html used on product pages (presumably to prevent their platform being abused). This translates to it automatically removing non-standard tags (such as `<lite-youtube>`) at frequent intervals.

I'm proposing a solution that will extend the `<video>` tag (while retaining full compatibility with parameters, etc), which will allow the script to pass parsing / linting on strict tools / validators.

Under the hood, the `<video lite-youtube>` tags are simply transformed into `<lite-youtube>` tags on script load - I've tried to keep the customisation as minimal as possible.

✅ Read and followed the contribution guidelines (..at least to the best of my ability..)
✅ Tests Updated & Passing

If this is out of scope for your project, completely understand if you reject the PR!

Thanks kindly!