### PR TITLE
fix(iframe): adds strict-origin-when-cross-origin referrerpolicy to iframe to help resolve player error 153

### DIFF
--- a/lite-youtube.ts
+++ b/lite-youtube.ts
@@ -324,7 +324,7 @@ export class LiteYTEmbed extends HTMLElement {
 
     return `
 <iframe credentialless frameborder="0" title="${this.videoTitle}"
-  referrerpolicy=“strict-origin-when-cross-origin”
+  referrerpolicy="strict-origin-when-cross-origin"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen
   src="https://www.youtube${wantsNoCookie}.com/embed/${embedTarget}autoplay=${autoplay}${autoPause}&${this.params}"
 ></iframe>`;


### PR DESCRIPTION
Adds `referrerpolicy=“strict-origin-when-cross-origin”` to the iframe embed to hopefully resolve YouTubes error 153. YouTube has this included in their embed code snippet when you go to embed a video on YouTube.com. 

<img width="1261" height="473" alt="Screenshot 2025-10-27 at 4 53 40 PM" src="https://github.com/user-attachments/assets/f65eb473-91c6-4200-b524-9045d68dab0e" />


Closes #140 