### PR TITLE
feat: Display video title with showTitleBeforeLoad

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ import '@justinribeiro/lite-youtube';
 If you want the paste-and-go version, you can simply load it via CDN:
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
+<script
+  type="module"
+  src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"
+></script>
 ```
 
 ## Basic Usage
@@ -71,7 +74,12 @@ A fallback appears in any of the following circumstances:
 
 ```html
 <lite-youtube videoid="guJLfqTFfIw">
-  <a class="lite-youtube-fallback" href="https://www.youtube.com/watch?v=guJLfqTFfIw">Watch on YouTube: "Sample output of devtools-to-video cli tool"</a>
+  <a
+    class="lite-youtube-fallback"
+    href="https://www.youtube.com/watch?v=guJLfqTFfIw"
+  >
+    Watch on YouTube: "Sample output of devtools-to-video cli tool"
+  </a>
 </lite-youtube>
 ```
 
@@ -79,33 +87,33 @@ Example CSS:
 
 ```css
 .lite-youtube-fallback {
-	aspect-ratio: 16 / 9; /* matches YouTube player */
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	flex-direction: column;
-	gap: 1em;
-	padding: 1em;
-	background-color: #000;
-	color: #fff;
-	text-decoration: none;
+  aspect-ratio: 16 / 9; /* matches YouTube player */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: 1em;
+  padding: 1em;
+  background-color: #000;
+  color: #fff;
+  text-decoration: none;
 }
 
 /* right-facing triangle "Play" icon */
 .lite-youtube-fallback::before {
-	display: block;
-	content: '';
-	border: solid transparent;
-	border-width: 2em 0 2em 3em;
-	border-left-color: red;
+  display: block;
+  content: '';
+  border: solid transparent;
+  border-width: 2em 0 2em 3em;
+  border-left-color: red;
 }
 
 .lite-youtube-fallback:hover::before {
-	border-left-color: #fff;
+  border-left-color: #fff;
 }
 
 .lite-youtube-fallback:focus {
-	outline: 2px solid red;
+  outline: 2px solid red;
 }
 ```
 
@@ -126,6 +134,16 @@ Setting the YouTube playlistid allows the playlist interface to load on interact
 <lite-youtube
   videotitle="This is a video title"
   videoid="guJLfqTFfIw"
+></lite-youtube>
+```
+
+## Show video title before iframe loads
+
+```html
+<lite-youtube
+  videotitle="This is a video title"
+  videoid="guJLfqTFfIw"
+  showTitleBeforeLoad
 ></lite-youtube>
 ```
 
@@ -189,13 +207,15 @@ Uses Intersection Observer if available to automatically load the YouTube iframe
 ```
 
 ## Use the named slot to set a custom poster image
+
 ```html
 <lite-youtube videoid="guJLfqTFfIw">
-  <img slot="image" src="my-poster-override.jpg">
+  <img slot="image" src="my-poster-override.jpg" />
 </lite-youtube>
 ```
 
 ## Set custom aspect ratio
+
 ```html
 <style>
   lite-youtube {
@@ -206,6 +226,7 @@ Uses Intersection Observer if available to automatically load the YouTube iframe
 ```
 
 ## Disable the frame shadow (flat look)
+
 ```html
 <style>
   lite-youtube {
@@ -217,6 +238,7 @@ Uses Intersection Observer if available to automatically load the YouTube iframe
 ```
 
 ## Customize the play button
+
 ```html
 <style>
   lite-youtube::part(playButton) {
@@ -227,15 +249,19 @@ Uses Intersection Observer if available to automatically load the YouTube iframe
 ```
 
 ## Auto-Pause video when scrolled out of view
+
 Note: the custom poster image will load with this set, but will then disappear without any user interaction because of the intersection observer starting.
+
 ```html
- <lite-youtube videoid="VLrYOji75Vc" autopause></lite-youtube>
+<lite-youtube videoid="VLrYOji75Vc" autopause></lite-youtube>
 ```
 
 ## NoScript disable
+
 As of v1.7.0, we inject into the lightdom a noscript for SEO help. This can conflict with server side rendered noscript injects. To disable, simply pass `disablenoscript` to the component:
+
 ```html
- <lite-youtube videoid="VLrYOji75Vc" disablenoscript></lite-youtube>
+<lite-youtube videoid="VLrYOji75Vc" disablenoscript></lite-youtube>
 ```
 
 ## YouTube QueryParams
@@ -249,32 +275,32 @@ Use any [YouTube Embedded Players and Player Parameters](https://developers.goog
 </lite-youtube>
 ```
 
-
 ## Attributes
 
 The web component allows certain attributes to be give a little additional
 flexibility.
 
-| Name              | Description                                                                   | Default     |
-|-------------------|-------------------------------------------------------------------------------|-------------|
-| `videoid`         | The YouTube videoid                                                           | ``          |
-| `playlistid`      | The YouTube playlistid; requires a videoid for thumbnail                      | ``          |
-| `videotitle`      | The title of the video                                                        | `Video`     |
-| `videoplay`       | The title of the play button (for translation)                                | `Play`      |
-| `videoStartAt`    | Set the point at which the video should start, in seconds                     | `0`         |
-| `posterquality`   | Set thumbnail poster quality (maxresdefault, sddefault, mqdefault, hqdefault) | `hqdefault` |
-| `posterloading`   | Set img lazy load attr `loading` for poster image                             | `lazy`      |
-| `nocookie`        | Use youtube-nocookie.com as iframe embed uri                                  | `false`     |
-| `autoload`        | Use Intersection Observer to load iframe when scrolled into view              | `false`     |
-| `autopause`       | Use video auto-pausing when scrolled out of view                              | `false`     |
-| `short`           | Show 9:16 YouTube Shorts-style interaction on mobile devices                  | `false`     |
-| `disablenoscript` | Disables `noscript` injector added to lightdom for search indexing            | `false`     |
-| `params`          | Set YouTube query parameters                                                  | ``          |
+| Name                  | Description                                                                   | Default     |
+| --------------------- | ----------------------------------------------------------------------------- | ----------- |
+| `videoid`             | The YouTube videoid                                                           | ``          |
+| `playlistid`          | The YouTube playlistid; requires a videoid for thumbnail                      | ``          |
+| `videotitle`          | The title of the video                                                        | `Video`     |
+| `showTitleBeforeLoad` | Show the `[videotitle]` before the iframe loads                               | `false`     |
+| `videoplay`           | The title of the play button (for translation)                                | `Play`      |
+| `videoStartAt`        | Set the point at which the video should start, in seconds                     | `0`         |
+| `posterquality`       | Set thumbnail poster quality (maxresdefault, sddefault, mqdefault, hqdefault) | `hqdefault` |
+| `posterloading`       | Set img lazy load attr `loading` for poster image                             | `lazy`      |
+| `nocookie`            | Use youtube-nocookie.com as iframe embed uri                                  | `false`     |
+| `autoload`            | Use Intersection Observer to load iframe when scrolled into view              | `false`     |
+| `autopause`           | Use video auto-pausing when scrolled out of view                              | `false`     |
+| `short`               | Show 9:16 YouTube Shorts-style interaction on mobile devices                  | `false`     |
+| `disablenoscript`     | Disables `noscript` injector added to lightdom for search indexing            | `false`     |
+| `params`              | Set YouTube query parameters                                                  | ``          |
 
 ## Events
 
 The web component fires events to give the ability understand important lifecycle.
 
 | Event Name                | Description                                      | Returns                             |
-|---------------------------|--------------------------------------------------|-------------------------------------|
+| ------------------------- | ------------------------------------------------ | ----------------------------------- |
 | `liteYoutubeIframeLoaded` | When the iframe is loaded, allowing us of JS API | `detail: { videoId: this.videoId }` |

--- a/demo/index.html
+++ b/demo/index.html
@@ -49,6 +49,17 @@
       videotitle="This is a video title"
     ></lite-youtube>
 
+    <h3>Show video title before iframe loads</h3>
+    <pre>
+
+&lt;lite-youtube videoid=&quot;guJLfqTFfIw&quot; videotitle=&quot;This is a video title&quot; showTitleBeforeLoad&gt;&lt;/lite-youtube&gt;
+    </pre>
+    <lite-youtube
+      videoid="guJLfqTFfIw"
+      videotitle="This is a video title"
+      showTitleBeforeLoad
+    ></lite-youtube>
+
     <h3>Change "Play" for Locale</h3>
     <pre>
 

--- a/lite-youtube.ts
+++ b/lite-youtube.ts
@@ -123,6 +123,10 @@ export class LiteYTEmbed extends HTMLElement {
     return this.hasAttribute('disablenoscript');
   }
 
+  get showTitleBeforeLoad(): boolean {
+    return this.hasAttribute('showtitlebeforeload');
+  }
+
   /**
    * Define our shadowDOM for the component
    */
@@ -169,17 +173,42 @@ export class LiteYTEmbed extends HTMLElement {
           height: 100%;
         }
 
+        #frame::before {
+          box-sizing: border-box;
+          color: #fff;
+          content: '';
+          display: block;
+          font-family: "YouTube Noto", Roboto, Arial, Helvetica, sans-serif;
+          font-size: 18px;
+          font-weight: 500;
+          line-height: 1.2;
+          position: absolute;
+          top: 0;
+          height: 60px;
+          width: 100%;
+          padding-block: 12px;
+          padding-inline: 16px;
+          z-index: 1;
+          pointer-events: none;
+        }
+
         @container style(--frame-shadow-visible: yes) {
           #frame::before {
-            content: '';
-            display: block;
-            position: absolute;
-            top: 0;
             background-image: linear-gradient(180deg, #111 -20%, transparent 90%);
-            height: 60px;
-            width: 100%;
-            z-index: 1;
           }
+        }
+
+        ${
+          this.showTitleBeforeLoad
+            ? `
+              #frame:not(.activated)::before {
+                content: '${this.videoTitle}';
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              }
+            `
+            : ''
         }
 
         #playButton {
@@ -390,7 +419,9 @@ export class LiteYTEmbed extends HTMLElement {
       const response = await fetch(oEmbedUrl);
 
       if (!response.ok) {
-        throw new Error(`Failed to fetch playlist thumbnail: ${response.status}`);
+        throw new Error(
+          `Failed to fetch playlist thumbnail: ${response.status}`,
+        );
       }
 
       const data = await response.json();

--- a/test/lite-youtube.test.ts
+++ b/test/lite-youtube.test.ts
@@ -297,4 +297,27 @@ describe('<lite-youtube>', () => {
     const el = await fixture<LiteYTEmbed>(baseTemplate);
     await expect(el).shadowDom.to.be.accessible();
   });
+
+  it('shows video title before iframe loads', async () => {
+    const el = await fixture<LiteYTEmbed>(
+      html`<lite-youtube
+        videoTitle="Test me"
+        videoid="guJLfqTFfIw"
+        showTitleBeforeLoad
+      ></lite-youtube>`,
+    );
+    await elementUpdated(el);
+
+    const frameEl = el.shadowRoot.querySelector('#frame');
+
+    if (!frameEl) return;
+
+    const beforeStyle = window.getComputedStyle(frameEl, '::before');
+
+    expect(beforeStyle.content).to.equal('"Test me"');
+
+    el.click();
+
+    expect(beforeStyle.content).to.equal('""');
+  });
 });


### PR DESCRIPTION
## Description

- Resolves #142 
- Add the `showTitleBeforeLoad` attribute to show the value from `[videoTitle]` before the iframe loads
- After the iframe load, the video title no longer shows since the actual YouTube title is now visible.
- NOTE: prettier auto formatted the full README file. If this causes any issues I can revert that file and only update the parts that I changed

## How To Test

- Add `videoTitle` and `showTitleBeforeLoad` attributes to any lite-youtube element
- Verify the videotitle is visible at the top of the alongside the placeholder image
- Click the Play button to load the iframe
- Verify the videotitle is no longer shown
